### PR TITLE
Feature/import run marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.5.1 (unreleased)
+
+- **Import-run markers for shared databases.** Every `import` invocation records a row in a new `crunch_uml_runs` table (outside the ORM model, like `crunch_uml_meta`, so it never leaks into exports): `run_id`, `schema_id`, `started_at`, `crunch_version`, `datamodel_version`, and a `completed_at` that is stamped as the FINAL step after the import committed. A row with `completed_at` NULL marks an in-progress or aborted (torn) run — external readers of a shared crunch database (e.g. an import API) should only consume schemas whose latest run is completed. The markers use their own connection, so they survive a session rollback as evidence, and a database recreate clears them (the data they vouched for is gone).
+- **Safe datamodel-version handling for shared databases.** New global flag `-on_version_mismatch {auto,fail,recreate}` controls what happens when a database was written with an incompatible datamodel version. `recreate` keeps the historical behaviour (drop and rebuild, all data discarded); `fail` stops with a clear error without touching the database; the default `auto` recreates only the local default database and fails on any explicitly provided `-db_url` — a mismatched crunch_uml version can no longer accidentally wipe a shared (staging) database.
+- **PostgreSQL extra.** `pip install 'crunch_uml[postgres]'` installs the psycopg2 driver for `-db_url postgresql://...` staging workflows; documented in the import manual (NL/EN) together with the run-marker/version-policy contract.
+
 ## v0.5.0 (unreleased)
 
 - **Datamodel version marker in the database.** Every crunch_uml database now stores a datamodel version in a `crunch_uml_meta` table (kept outside the ORM model so it never leaks into exports). On connect, a database with the same version — or one predating the marker — is migrated additively (missing tables/nullable columns are added, data kept); a database with a different version is incompatible and is recreated from scratch with a clear warning, after which models must be re-imported. The version is only bumped for schema changes the additive migration cannot handle.

--- a/crunch_uml/cli.py
+++ b/crunch_uml/cli.py
@@ -140,19 +140,28 @@ def main(args=None):
                 return
 
             # Get daatbase and optionaly create new one
-            database = Database(args.database_url, db_create=args.database_create_new)
+            database = Database(
+                args.database_url,
+                db_create=args.database_create_new,
+                on_version_mismatch=args.on_version_mismatch,
+            )
             schema = sch.Schema(database, schema_name=args.schema_name)
+            # Run marker: row with completed_at NULL means "in progress or
+            # aborted"; completed_at is stamped as the FINAL step after the
+            # commit, so external readers only consume consistent schemas.
+            run_id = database.start_import_run(args.schema_name)
             try:
                 # First open database, select parser and parse into database
                 logger.info(f"Starting parsing with inputtype {args.inputtype}")
                 parser = parsers.ParserRegistry.getinstance(args.inputtype)
                 parser.parse(args, schema)
                 database.commit()
+                database.complete_import_run(run_id)
                 logger.info("Succes! parsed all data and saved it in database")
             except Exception as ex:
                 logger.error(
                     f"Error while parsing file, writing data to database with message: {ex}. Exiting and"
-                    " descarding all changes to database."
+                    " descarding all changes to database. The import run marker stays incomplete."
                 )
                 database.rollback()
                 raise
@@ -161,7 +170,7 @@ def main(args=None):
 
         # Do transformation
         elif args.command == const.CMD_TRANSFORM:
-            database = Database(args.database_url, db_create=False)
+            database = Database(args.database_url, db_create=False, on_version_mismatch=args.on_version_mismatch)
             logger.info("Starting transformation ")
             try:
                 transformer = transformers.TransformerRegistry.getinstance(args.transformationtype)
@@ -183,7 +192,7 @@ def main(args=None):
 
         # Render Output
         elif args.command == const.CMD_EXPORT:
-            database = Database(args.database_url, db_create=False)
+            database = Database(args.database_url, db_create=False, on_version_mismatch=args.on_version_mismatch)
             schema = sch.Schema(database, schema_name=args.schema_name)
             logger.info(f"Starting rendering with outputtype {args.outputtype}")
             renderer = renderers.RendererRegistry.getinstance(args.outputtype)

--- a/crunch_uml/const.py
+++ b/crunch_uml/const.py
@@ -17,6 +17,13 @@ ENCODING = "utf-8"
 CMD_IMPORT = "import"
 CMD_EXPORT = "export"
 CMD_TRANSFORM = "transform"
+
+# Policy when the database's stored datamodel version does not match this
+# build's DATAMODEL_VERSION. 'auto' resolves to 'recreate' for the local
+# default database and to 'fail' for any explicitly provided db_url.
+VERSION_MISMATCH_AUTO = "auto"
+VERSION_MISMATCH_FAIL = "fail"
+VERSION_MISMATCH_RECREATE = "recreate"
 # CMD_CHECK = 'check'
 # CMD_FIX = 'fix'
 

--- a/crunch_uml/db.py
+++ b/crunch_uml/db.py
@@ -1,6 +1,9 @@
+import importlib.metadata
 import logging
 import re
+import uuid
 import warnings
+from datetime import datetime, timezone
 
 import inflection
 from sqlalchemy import (
@@ -55,6 +58,30 @@ crunch_meta_table = Table(
     Column("value", String),
 )
 
+# Import-run bookkeeping, also outside Base.metadata for the same reason.
+# One row per `import` invocation. `completed_at` is written as the FINAL
+# step after the import committed; a row with completed_at IS NULL therefore
+# marks an in-progress or aborted (torn) run. External readers of a shared
+# crunch database (e.g. the Semantic Toolkit's import API) must only consume
+# schemas whose latest run is completed.
+crunch_runs_table = Table(
+    "crunch_uml_runs",
+    _meta_metadata,
+    Column("run_id", String, primary_key=True),
+    Column("schema_id", String, nullable=False),
+    Column("started_at", String, nullable=False),  # ISO-8601 UTC
+    Column("completed_at", String, nullable=True),  # ISO-8601 UTC, NULL = torn
+    Column("crunch_version", String, nullable=True),
+    Column("datamodel_version", String, nullable=True),
+)
+
+
+def _crunch_version():
+    try:
+        return importlib.metadata.version("crunch_uml")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
 
 def add_args(argumentparser, subparser_dict):
     global suppress_warnings
@@ -81,6 +108,19 @@ def add_args(argumentparser, subparser_dict):
             f" supported database. Default is {const.DATABASE_URL}"
         ),
         default=const.DATABASE_URL,
+    )
+    argumentparser.add_argument(
+        "-on_version_mismatch",
+        "--on_version_mismatch",
+        type=str,
+        choices=[const.VERSION_MISMATCH_AUTO, const.VERSION_MISMATCH_FAIL, const.VERSION_MISMATCH_RECREATE],
+        help=(
+            "What to do when the database was written with an incompatible datamodel version:"
+            " 'recreate' drops and rebuilds it (ALL data discarded), 'fail' stops without touching it."
+            " Default 'auto': recreate only the local default database, fail on any explicitly"
+            " provided -db_url (assumed shared/precious, e.g. a staging Postgres)."
+        ),
+        default=const.VERSION_MISMATCH_AUTO,
     )
 
 
@@ -1341,13 +1381,16 @@ class Diagram(Base, UMLBase):  # type: ignore
 class Database:
     _instance = None
 
-    def __new__(cls, db_url=const.DATABASE_URL, db_create=False):
+    def __new__(cls, db_url=const.DATABASE_URL, db_create=False, on_version_mismatch=const.VERSION_MISMATCH_AUTO):
         if cls._instance is None:
             cls._instance = super(Database, cls).__new__(cls)
             # Setting up the database
             cls._instance.engine = create_engine(db_url)
             Session = sessionmaker(bind=cls._instance.engine)
             cls._instance.session = Session()
+            cls._instance._db_url = db_url
+        # Policy may differ per invocation (CLI flag), so set it on every call.
+        cls._instance._on_version_mismatch = on_version_mismatch
         if db_create:
             cls._instance._reset_database()
 
@@ -1358,6 +1401,17 @@ class Database:
         Base.metadata.drop_all(bind=self.engine)  # Drop all tables
         Base.metadata.create_all(bind=self.engine)  # Create all tables
         self._write_datamodel_version()
+        # The model data the run markers vouched for is gone — stale
+        # "completed" rows would falsely promise consistent schemas.
+        self._clear_import_runs()
+
+    def _clear_import_runs(self):
+        try:
+            _meta_metadata.create_all(bind=self.engine, checkfirst=True)
+            with self.engine.begin() as connection:
+                connection.execute(crunch_runs_table.delete())
+        except OperationalError as e:
+            logger.warning(f"Could not clear import run markers: {e}")
 
     def _check_and_create_database(self):
         try:
@@ -1368,21 +1422,88 @@ class Database:
             else:
                 stored_version = self._read_datamodel_version()
                 if stored_version is not None and stored_version != DATAMODEL_VERSION:
-                    # Incompatible datamodel: recreate the database. A None
-                    # version means the database predates the version marker
-                    # and is still additively migratable.
-                    logger.warning(
-                        f"Database has datamodel version {stored_version}, this version of crunch_uml"
-                        f" requires {DATAMODEL_VERSION}: recreating the database. All data is discarded;"
-                        " re-import your models."
-                    )
-                    self._reset_database()
+                    # Incompatible datamodel. A None version means the database
+                    # predates the version marker and is still additively
+                    # migratable. What happens next depends on the mismatch
+                    # policy: the historical behaviour (recreate, all data
+                    # discarded) is only safe for the local throwaway default
+                    # database — on any explicitly provided db_url (a shared
+                    # Postgres staging database, say) we fail fast instead.
+                    if self._resolve_version_mismatch_policy() == const.VERSION_MISMATCH_RECREATE:
+                        logger.warning(
+                            f"Database has datamodel version {stored_version}, this version of crunch_uml"
+                            f" requires {DATAMODEL_VERSION}: recreating the database. All data is discarded;"
+                            " re-import your models."
+                        )
+                        self._reset_database()
+                    else:
+                        raise CrunchException(
+                            f"Database has datamodel version {stored_version}, but this version of"
+                            f" crunch_uml requires {DATAMODEL_VERSION}. Refusing to touch it: recreating"
+                            " would discard ALL data in this database. Re-run with"
+                            " '-on_version_mismatch recreate' (or -db_create) to rebuild it, or use a"
+                            " matching crunch_uml version."
+                        )
                 else:
                     self._add_missing_tables_and_columns(inspector)
         except OperationalError:
             # If the database does not exist or is not reachable, create it
             Base.metadata.create_all(bind=self.engine)
         self._write_datamodel_version()
+
+    def _resolve_version_mismatch_policy(self):
+        """Effective mismatch policy: an explicit CLI choice wins; 'auto'
+        recreates only the local default database and fails on anything else
+        (an explicitly provided db_url is assumed to be shared/precious)."""
+        policy = getattr(self, "_on_version_mismatch", const.VERSION_MISMATCH_AUTO)
+        if policy != const.VERSION_MISMATCH_AUTO:
+            return policy
+        if getattr(self, "_db_url", const.DATABASE_URL) == const.DATABASE_URL:
+            return const.VERSION_MISMATCH_RECREATE
+        return const.VERSION_MISMATCH_FAIL
+
+    def start_import_run(self, schema_id):
+        """Insert an import-run row (completed_at NULL) and return its run_id.
+
+        Uses its own connection, independent of the ORM session: the row must
+        be visible to concurrent readers *while* the import is still running,
+        and must survive a session rollback as evidence of a torn run.
+        Best-effort: bookkeeping failure never blocks an import.
+        """
+        run_id = str(uuid.uuid4())
+        try:
+            _meta_metadata.create_all(bind=self.engine, checkfirst=True)
+            with self.engine.begin() as connection:
+                connection.execute(
+                    insert(crunch_runs_table).values(
+                        run_id=run_id,
+                        schema_id=schema_id,
+                        started_at=datetime.now(timezone.utc).isoformat(),
+                        completed_at=None,
+                        crunch_version=_crunch_version(),
+                        datamodel_version=str(DATAMODEL_VERSION),
+                    )
+                )
+            return run_id
+        except OperationalError as e:
+            logger.warning(f"Could not record import run start: {e}")
+            return None
+
+    def complete_import_run(self, run_id):
+        """Stamp completed_at on the run row. Call as the FINAL step, after
+        the import transaction committed — the marker is the contract that
+        tells external readers the schema is consistent."""
+        if run_id is None:
+            return
+        try:
+            with self.engine.begin() as connection:
+                connection.execute(
+                    update(crunch_runs_table)
+                    .where(crunch_runs_table.c.run_id == run_id)
+                    .values(completed_at=datetime.now(timezone.utc).isoformat())
+                )
+        except OperationalError as e:
+            logger.warning(f"Could not record import run completion: {e}")
 
     def _read_datamodel_version(self):
         """Version marker stored in the database, or None when the database

--- a/docs/handleiding/import.en.md
+++ b/docs/handleiding/import.en.md
@@ -87,3 +87,21 @@ Now both versions are side by side in the same database and you can compare them
 ```bash
 crunch_uml -sch translation_en import -f translations.json -t i18n --language en
 ```
+
+### Shared database as import staging (run markers and version policy)
+
+When crunch_uml writes to a shared database (say, a PostgreSQL staging database another application reads from), v0.5.1 adds two safeguards:
+
+**Run markers.** Every `import` invocation writes a row to the `crunch_uml_runs` table (outside the data model, so it never leaks into exports): at the start with an empty `completed_at`, and only after the successful commit is `completed_at` stamped as the very last step. External readers should only consume schemas whose latest run has a `completed_at` — a row without one means "in progress or aborted" (crunch_uml writes table-by-table, non-transactionally, so reading halfway yields a torn model).
+
+**Version policy.** When a database carries a different datamodel version, `-on_version_mismatch` decides what happens: `recreate` (historical behaviour: discard everything and rebuild), `fail` (stop without touching anything), or the default `auto` — which only recreates the local default database and fails on any explicitly provided `-db_url`. A mismatched crunch_uml version can therefore no longer accidentally wipe a shared staging database:
+
+```bash
+# Staging workflow: GGM into a PostgreSQL staging database, one schema per release
+pip install 'crunch_uml[postgres]'
+crunch_uml -db_url postgresql://crunch_writer:***@staging-host/crunch_staging \
+  -sch ggm_2_5_1 import -f "Gemeentelijk Gegevensmodel XMI2.1.xml" -t eaxmi
+
+# Deliberately recreate after a crunch_uml upgrade with a datamodel change:
+crunch_uml -db_url postgresql://... -on_version_mismatch recreate -sch ggm_2_5_1 import -f model.xml -t eaxmi
+```

--- a/docs/handleiding/import.md
+++ b/docs/handleiding/import.md
@@ -87,3 +87,21 @@ Nu staan beide versies naast elkaar in dezelfde database en kun je ze vergelijke
 ```bash
 crunch_uml -sch vertaling_en import -f translations.json -t i18n --language en
 ```
+
+### Gedeelde database als import-staging (run-markers en versiebeleid)
+
+Wie crunch_uml naar een gedeelde database laat schrijven (bijvoorbeeld een PostgreSQL-stagingdatabase waar een andere applicatie uit leest) krijgt sinds v0.5.1 twee waarborgen:
+
+**Run-markers.** Elke `import`-aanroep schrijft een rij in de tabel `crunch_uml_runs` (buiten het datamodel, lekt dus nooit mee in exports): bij de start met een lege `completed_at`, en pas ná de succesvolle commit wordt `completed_at` als allerlaatste stap gevuld. Externe lezers horen alleen schema's te consumeren waarvan de laatste run een `completed_at` heeft — een rij zonder betekent "bezig of afgebroken" (crunch_uml schrijft niet-transactioneel tabel-voor-tabel, dus halverwege meelezen levert een gescheurd model op).
+
+**Versiebeleid.** Bij een database met een afwijkende datamodel-versie bepaalt `-on_version_mismatch` wat er gebeurt: `recreate` (historisch gedrag: alles weggooien en opnieuw opbouwen), `fail` (stoppen zonder iets aan te raken) of het standaard-`auto` — dat alleen de lokale default-database hercreëert en op elke expliciet opgegeven `-db_url` faalt. Een verkeerde crunch_uml-versie kan een gedeelde stagingdatabase dus niet meer per ongeluk leegmaken:
+
+```bash
+# Staging-workflow: GGM naar een PostgreSQL-stagingdatabase, schema per release
+pip install 'crunch_uml[postgres]'
+crunch_uml -db_url postgresql://crunch_writer:***@staging-host/crunch_staging \
+  -sch ggm_2_5_1 import -f "Gemeentelijk Gegevensmodel XMI2.1.xml" -t eaxmi
+
+# Bewust hercreëren na een crunch_uml-upgrade met datamodelwijziging:
+crunch_uml -db_url postgresql://... -on_version_mismatch recreate -sch ggm_2_5_1 import -f model.xml -t eaxmi
+```

--- a/docs/handleiding/installatie.en.md
+++ b/docs/handleiding/installatie.en.md
@@ -6,6 +6,12 @@
 pip install crunch-uml
 ```
 
+To write to a PostgreSQL database (for instance a shared import staging, see the import manual), install the postgres extra as well:
+
+```bash
+pip install 'crunch_uml[postgres]'
+```
+
 After installation, the `crunch_uml` command is available:
 
 ```bash

--- a/docs/handleiding/installatie.md
+++ b/docs/handleiding/installatie.md
@@ -6,6 +6,12 @@
 pip install crunch-uml
 ```
 
+Wil je naar een PostgreSQL-database schrijven (bijvoorbeeld een gedeelde import-staging, zie de importhandleiding), installeer dan de postgres-extra mee:
+
+```bash
+pip install 'crunch_uml[postgres]'
+```
+
 Na installatie is het commando `crunch_uml` beschikbaar:
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def parse_requirements(filename):
 
 setuptools.setup(
     name='crunch_uml',
-    version='0.5.0',
+    version='0.5.1',
     description="Crunch_uml reads UML Class model from multiple formats (including XMI, Enterprise Architect XMI, Excel, Json, and others), can perform transformations and renders them to other formats (including Markdown, json, json schema and many others).",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -39,6 +39,9 @@ setuptools.setup(
     ],
     install_requires=parse_requirements('requirements.txt'),
     extras_require={
+        'postgres': [
+            'psycopg2-binary >= 2.9, < 3',
+        ],
         'dev':[
             'bandit == 1.7.*',
             'black >= 26.3.1, < 27',

--- a/tasks/diagram-geometry-support.md
+++ b/tasks/diagram-geometry-support.md
@@ -1,0 +1,129 @@
+# Crunch_uml — volledige diagram-ondersteuning (membership + geometrie)
+
+## Context en doel
+
+Crunch_uml wordt de brug tussen Sparx Enterprise Architect (waarin het GGM wordt onderhouden) en de Semantic Toolkit. De toolkit gaat GGM-modellen inlezen **inclusief diagrammen mét layout**: posities en afmetingen van klassen/enumeraties op een diagram, en het verloop (waypoints) van associatie- en generalisatielijnen.
+
+Crunch kent diagrammen nu alleen als membership-lijst (welke elementen staan op welk diagram). Deze upgrade voegt de **geometrie** toe, end-to-end:
+
+1. Datamodel uitbreiden met geometrievelden.
+2. Parsers (`eaxmi`, `qea`) lezen geometrie in.
+3. Een **nieuwe XMI-renderer** schrijft modellen inclusief diagrammen + geometrie weg als EA-compatibele XMI.
+4. Daarna moeten **alle** renderers en parsers met de uitgebreide diagrammen overweg kunnen (round-trip via json/csv/xlsx, write-back naar EA-repo, en expliciete n.v.t.-documentatie voor semantische renderers).
+
+Werk in fasen, in deze volgorde. Elke fase eindigt groen (pytest, mypy, ruff) en wordt apart gecommit.
+
+## Huidige staat (verifieer eerst zelf)
+
+- `crunch_uml/db.py`: `Diagram` (UMLBase: id, schema_id, name, author, version, created, modified, definitie; plus package_id) met koppeltabellen `DiagramClass`, `DiagramEnumeration`, `DiagramAssociation`, `DiagramGeneralization`. Composite PK (diagram_id, schema_id, element_id). **Geen geometrie.**
+- `crunch_uml/parsers/eaxmiparser.py` (~regel 230–310): leest `<diagram>`-elementen uit de EA-extension-sectie, koppelt membership via `subject`-idrefs, maar **negeert het `geometry`-attribuut** volledig. Een voorbeeld van de XML staat als docstring in de code.
+- `crunch_uml/parsers/qeaparser.py`: leest t_package, t_object, t_attribute, t_connector en tagged values, maar **geen enkele diagram-tabel**. Diagram-membership ontbreekt dus volledig bij `.qea`-import.
+- `crunch_uml/parsers/xmiparser.py` (strict XMI): kent geen diagrammen — strict XMI 2.1 bevat ze niet. Blijft zo.
+- Renderers: er bestaat **geen XMI-renderer**. `earepo`/`eamimrepo` (`renderers/earepoupdater.py`, ~regel 1180) updaten alleen `t_diagram`-metadata (naam e.d.), geen diagramobjects/links.
+- Generieke parsers/renderers (`json`, `csv`, `xlsx`, `i18n` in `parsers/multiple_parsers.py` en `renderers/pandasrenderer.py`) itereren over `db.getTables()` en pikken nieuwe kolommen dus grotendeels automatisch op — maar let op: de *indexed* variant slaat tabellen zonder `id`-kolom over, en de koppeltabellen hebben geen `id`. Controleer per formaat wat er nu al wel/niet doorheen komt en dek het af met tests.
+- `Diagram.get_copy()` kopieert alleen class- en enum-membership (geen associations/generalizations — bestaande omissie) en straks dus ook nog geen geometrie.
+
+## Fase 1 — datamodel
+
+Breid de vier koppeltabellen uit. Alle nieuwe kolommen **nullable** (membership zonder bekende layout blijft geldig; bestaande fixtures/databases zonder geometrie moeten blijven werken).
+
+Node-achtig (`DiagramClass`, `DiagramEnumeration`):
+
+| Kolom | Type | Betekenis |
+| --- | --- | --- |
+| `x` | Float | linkerkant, canonieke coördinaten |
+| `y` | Float | bovenkant, canonieke coördinaten |
+| `width` | Float | breedte |
+| `height` | Float | hoogte |
+| `z_order` | Integer | stapelvolgorde (EA `seqno`/`Sequence`) |
+| `ea_style` | Text | ruwe EA style-string, lossless bewaren voor round-trip |
+
+Edge-achtig (`DiagramAssociation`, `DiagramGeneralization`):
+
+| Kolom | Type | Betekenis |
+| --- | --- | --- |
+| `waypoints` | Text (JSON) | `[{"x": .., "y": ..}, ...]` in canonieke coördinaten; lege lijst/NULL = geen tussenpunten |
+| `hidden` | Boolean | EA `Hidden`-vlag |
+| `ea_geometry` | Text | ruwe EA geometry-string (SX/SY/EX/EY/EDGE/labelposities/Path) — lossless |
+| `ea_style` | Text | ruwe EA style-string — lossless |
+
+**Canoniek coördinatenstelsel**: oorsprong linksboven, x naar rechts, y naar beneden, alles positief. Alle parser-/renderer-conversies van en naar EA-conventies gebeuren aan de rand; de database bevat alleen canonieke waarden. Leg dit vast in een module-docstring of `docs/technisch/datamodel.md`.
+
+Verder in deze fase:
+
+- `Diagram.get_copy()`: kopieer de nieuwe geometrievelden mee. Fix daarbij ook de bestaande omissie dat association-/generalization-membership niet gekopieerd wordt (of, als dat bewust is, documenteer het expliciet bij de methode).
+- Unit-tests voor het datamodel (aanmaken, kopiëren, cascade delete van diagram incl. geometrierijen).
+
+## Fase 2 — parsers
+
+### 2a. `eaxmi` (eaxmiparser.py)
+
+Parse het `geometry`-attribuut per `<element>` in `<diagram><elements>`:
+
+- **Nodes**: `geometry="Left=90;Top=30;Right=210;Bottom=90;"` → `x=90, y=30, width=120, height=60`. Hier zijn Top/Bottom al positief (schermcoördinaten). `seqno` → `z_order`, `style` → `ea_style`.
+- **Edges**: geometry bevat `SX/SY/EX/EY/EDGE`, labelposities (`$LLB`, `LLT`, `LMT`, `LMB`, `LRT`, `LRB`) en `Path=226:-205$256:-205$...` — x:y-paren gescheiden door `$`, **y is hier negatief** (EA-conventie). Converteer Path naar canonieke waypoints (y-teken flippen); bewaar de volledige string in `ea_geometry` en de style in `ea_style`, zet `hidden` op basis van `Hidden=1` in de style-string.
+
+Onbekende elementtypen (Notes, Constraints, referenties buiten het model) blijven zoals nu: debug-log en overslaan.
+
+### 2b. `qea` (qeaparser.py)
+
+Nieuw: lees de diagram-tabellen. Dit voegt voor `.qea` óók de nu ontbrekende membership toe:
+
+- `t_diagram`: Diagram_ID, ea_guid (→ id, zelfde GUID-naar-EAID-conversie als elders in de parser), Name, Package_ID, Author, Version, CreatedDate, ModifiedDate, Notes (→ definitie).
+- `t_diagramobjects`: Diagram_ID, Object_ID (join op t_object voor ea_guid), RectLeft, RectTop, RectRight, RectBottom, Sequence, ObjectStyle. **Let op: RectTop/RectBottom zijn negatief** in de qea-database: `y = -RectTop`, `height = RectTop - RectBottom` (controleer met een echt bestand). Object kan class of enumeratie zijn — route naar de juiste koppeltabel.
+- `t_diagramlinks`: DiagramID, ConnectorID (join op t_connector voor ea_guid), Geometry, Style, Hidden, Path. Zelfde Path-parsing en y-flip als bij 2a. Connector kan association of generalization zijn.
+
+### 2c. Tests fase 2
+
+- Gebruik bestaande fixtures: `test/data/GGM_Monumenten_EA2.1.xml` en `test/data/Monumenten.qea`. Assert voor minimaal één diagram concrete verwachte posities/afmetingen van een paar klassen en de waypoints van minimaal één relatie (lees de verwachte waarden uit de fixture zelf).
+- Cross-check: hetzelfde model via `eaxmi` en via `qea` ingelezen moet (bij benadering) dezelfde geometrie opleveren voor dezelfde elementen.
+- Bestaande tests (o.a. `test_01c_import_schuldhulpverlening.py`, `test_17_qea_parser.py`) blijven groen; membership-counts van qea-import wijzigen doordat diagrammen er nu bij komen — pas die tests bewust aan.
+
+## Fase 3 — nieuwe XMI-renderer
+
+Registreer een renderer `xmi` (in een nieuw bestand `renderers/xmirenderer.py`) die het complete model wegschrijft als **XMI 2.1 met EA-extension-sectie**, het spiegelbeeld van wat `eaxmiparser` leest:
+
+- Strikte deel: `uml:Model` met packagedElements (packages, classes incl. attributen, enumeraties incl. literals, associaties incl. ends/cardinaliteiten/rollen, generalisaties). Gebruik de bestaande ids als `xmi:id`.
+- Extension-deel: per diagram een `<diagram>` met properties/project-metadata en `<elements>` met per element het `geometry`-attribuut in EA-formaat — de exacte omkering van de fase-2-conversies (incl. y-flip voor Path). Gebruik `ea_geometry`/`ea_style` als die gevuld zijn; genereer anders minimale geldige strings uit de canonieke velden.
+- Doel-compatibiliteit: het bestand moet door de eigen `eaxmi`-parser gelezen kunnen worden **en** door Sparx EA importeerbaar zijn. Waar de XMI-spec en EA botsen wint EA; documenteer elke afwijking met een korte notitie in `renderers/EA_QUIRKS.md`.
+
+**Acceptatietest (de kern van deze hele upgrade)** — round-trip:
+
+```
+GGM_Monumenten_EA2.1.xml → [eaxmi parse] → schema A → [xmi render] → out.xml
+out.xml → [eaxmi parse] → schema B
+```
+
+Schema B is semantisch gelijk aan schema A: zelfde packages/classes/attributen/enums/associaties/generalisaties, zelfde diagram-membership, en **zelfde geometrie** (posities exact of binnen 1px, waypoints gelijk). Zelfde test ook met `Monumenten.qea` als startpunt. Handmatige EA-importcheck van `out.xml` hoort bij de definition-of-done van deze fase (noteer het resultaat in de PR/commit-message).
+
+## Fase 4 — alle overige renderers en parsers
+
+- **`json`, `csv`, `xlsx`, `i18n`** (renderers én parsers): de vier koppeltabellen inclusief nieuwe kolommen moeten volledig round-trippen: `parse eaxmi → render json → nieuwe db → parse json → render json` levert identieke geometrie. Onderzoek de bestaande junction-table-behandeling (indexed variant slaat tabellen zonder `id` over) en fix waar nodig. Backwards-compat: bestaande bestanden zónder geometriekolommen (bv. `test/data/Monumenten.json`) blijven importeerbaar.
+- **`earepo` / `eamimrepo`** (earepoupdater.py): schrijf geometrie terug naar `t_diagramobjects` en `t_diagramlinks` (update bestaande rijen; insert voor elementen die nieuw op een diagram staan; verwijder rijen waarvan de membership vervallen is). Zelfde coördinaatconversies als de qea-parser, omgekeerd. Test tegen een kopie van `Monumenten.qea` naar het patroon van `test_15_updateEAModel.py`.
+- **`sqla`**: controleer dat de nieuwe kolommen meekomen (vermoedelijk automatisch via ORM-metadata); test dekt het af.
+- **Semantische renderers** (`jinja2`, `ggm_md`, `json_schema`, `plain_html`, `model_overview_md`, `er_diagram`, `openapi`, `ttl`, `rdf`, `json-ld`, `shex`, `profile`, `uml_mmd`, `model_stats_md`, `diff_md`): geometrie is daar niet van toepassing. Niets bouwen, wél vastleggen: voeg in `docs/technisch/datamodel.md` een dekkings-matrix toe (parser/renderer × diagram-membership × geometrie: leest / schrijft / n.v.t.).
+- `renderers/lodrenderer copy.py` is dood bestand — negeren (of opruimen als losse commit).
+
+## EA-quirks — let op
+
+- XMI-extension node-geometrie heeft **positieve** Top/Bottom; `t_diagramobjects` heeft **negatieve** RectTop/RectBottom; `Path=`-coördinaten zijn in **beide** bronnen negatief in y. Verifieer elk van deze drie tegen echte bestanden voordat je de conversies vastlegt, en documenteer ze bij de conversiefuncties.
+- Label-geometrie (`LMT=CX=28:CY=14:...`) niet interpreteren — ruw bewaren in `ea_geometry` zodat de round-trip hem terug kan schrijven.
+- EA staat (zelden) hetzelfde element twee keer op één diagram toe; onze composite PK kan dat niet. Bekende beperking: eerste instantie wint, log een warning. Niet oplossen.
+- Zelfde element-GUID kan in `t_diagramobjects` naar een package of note verwijzen — alleen classes/enums/associations/generalizations verwerken, rest debug-loggen.
+
+## Kwaliteitseisen (elke fase)
+
+- `pytest` volledig groen; nieuwe functionaliteit heeft eigen tests (happy path + minimaal één failure/edge case).
+- `mypy` en `ruff check` schoon; formatteren met de bestaande project-setup.
+- CHANGELOG.md: één alinea per fase.
+- `docs/technisch/datamodel.md` (en `.en.md`) bijwerken bij fase 1 en fase 4.
+- Versiebump (minor) bij afronding van fase 4.
+- Conventional Commits; code/comments/docstrings in het Engels.
+
+## Out of scope
+
+- Notes/comments, constraints en andere niet-ondersteunde elementtypen op diagrammen.
+- Diagram-typen anders dan klassendiagrammen ("Logical").
+- Interpretatie van EA-stylestrings (kleuren, fonts) — alleen lossless doorgeven.
+- Auto-layout voor ontbrekende geometrie — consumenten (zoals de Semantic Toolkit) lossen dat zelf op.
+- Wijzigingen aan de strict-`xmi`-parser.

--- a/test/unit/test_30_run_marker_and_versioning.py
+++ b/test/unit/test_30_run_marker_and_versioning.py
@@ -1,0 +1,194 @@
+import json
+import sqlite3
+
+import pytest
+from sqlalchemy import select
+
+import crunch_uml.db as db
+from crunch_uml import cli, const
+from crunch_uml.db import DATAMODEL_VERSION, DATAMODEL_VERSION_KEY, crunch_runs_table
+
+MONUMENTEN = "./test/data/GGM_Monumenten_EA2.1.xml"
+
+
+def _dispose_singleton():
+    inst = db.Database._instance
+    if inst is not None:
+        try:
+            inst.session.close()
+        except Exception:  # noqa: S110 - best-effort teardown
+            pass
+        try:
+            inst.engine.dispose()
+        except Exception:  # noqa: S110 - best-effort teardown
+            pass
+        db.Database._instance = None
+
+
+@pytest.fixture(autouse=True)
+def _reset_database_singleton():
+    """The Database singleton survives across tests (export-only CLI runs
+    never close it, and a failed construction leaves engine+session behind).
+    Dispose BEFORE each test — so a stale instance from another test file
+    can't hijack our -db_url — and after, so we leave no stale one behind."""
+    _dispose_singleton()
+    yield
+    _dispose_singleton()
+
+
+def _sqlite_path(tmp_path, name):
+    return tmp_path / name
+
+
+def _db_url(path):
+    return f"sqlite:///{path}"
+
+
+def _fetch_runs(path):
+    con = sqlite3.connect(path)
+    try:
+        rows = con.execute(
+            "SELECT run_id, schema_id, started_at, completed_at, crunch_version, datamodel_version"
+            " FROM crunch_uml_runs ORDER BY started_at"
+        ).fetchall()
+    finally:
+        con.close()
+    return rows
+
+
+def _tamper_datamodel_version(path, value="999"):
+    con = sqlite3.connect(path)
+    try:
+        con.execute(
+            "UPDATE crunch_uml_meta SET value = ? WHERE key = ?",
+            (value, DATAMODEL_VERSION_KEY),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _read_version(path):
+    con = sqlite3.connect(path)
+    try:
+        row = con.execute("SELECT value FROM crunch_uml_meta WHERE key = ?", (DATAMODEL_VERSION_KEY,)).fetchone()
+    finally:
+        con.close()
+    return row[0] if row else None
+
+
+def _count_classes(path):
+    con = sqlite3.connect(path)
+    try:
+        return con.execute("SELECT COUNT(*) FROM classes").fetchone()[0]
+    finally:
+        con.close()
+
+
+def test_marker_completed_after_successful_import(tmp_path):
+    path = _sqlite_path(tmp_path, "marker.db")
+    rc = cli.main(["-db_url", _db_url(path), "import", "-f", MONUMENTEN, "-t", "eaxmi", "-db_create"])
+    assert rc == 0
+
+    runs = _fetch_runs(path)
+    assert len(runs) == 1
+    run_id, schema_id, started_at, completed_at, crunch_version, datamodel_version = runs[0]
+    assert schema_id == const.DEFAULT_SCHEMA
+    assert started_at is not None
+    assert completed_at is not None, "completion marker must be stamped after a successful import"
+    assert completed_at >= started_at
+    assert datamodel_version == str(DATAMODEL_VERSION)
+
+
+def test_marker_stays_incomplete_on_aborted_import(tmp_path):
+    path = _sqlite_path(tmp_path, "aborted.db")
+    broken = tmp_path / "broken.json"
+    broken.write_text("{ this is not valid json", encoding="utf-8")
+
+    rc = cli.main(["-db_url", _db_url(path), "import", "-f", str(broken), "-t", "json", "-db_create"])
+    assert rc == 1
+
+    runs = _fetch_runs(path)
+    assert len(runs) == 1
+    assert runs[0][3] is None, "aborted import must leave completed_at NULL (torn run)"
+
+
+def test_runs_table_never_leaks_into_exports(tmp_path):
+    path = _sqlite_path(tmp_path, "leak.db")
+    out = tmp_path / "export.json"
+    rc = cli.main(["-db_url", _db_url(path), "import", "-f", MONUMENTEN, "-t", "eaxmi", "-db_create"])
+    assert rc == 0
+    rc = cli.main(["-db_url", _db_url(path), "export", "-t", "json", "-f", str(out)])
+    assert rc == 0
+    exported = json.loads(out.read_text(encoding="utf-8"))
+    assert "crunch_uml_runs" not in exported
+    assert "crunch_uml_meta" not in exported
+
+
+def test_version_mismatch_on_explicit_db_url_fails_without_dropping(tmp_path):
+    path = _sqlite_path(tmp_path, "staging.db")
+    rc = cli.main(["-db_url", _db_url(path), "import", "-f", MONUMENTEN, "-t", "eaxmi", "-db_create"])
+    assert rc == 0
+    classes_before = _count_classes(path)
+    assert classes_before > 0
+    _tamper_datamodel_version(path)
+
+    # No -db_create, no policy flag: 'auto' on an explicit db_url must FAIL
+    # fast and leave the database untouched (council condition 2).
+    rc = cli.main(["-db_url", _db_url(path), "import", "-f", MONUMENTEN, "-t", "eaxmi"])
+    assert rc == 1
+    assert _read_version(path) == "999", "version marker must not be rewritten on refusal"
+    assert _count_classes(path) == classes_before, "no data may be dropped on refusal"
+
+
+def test_version_mismatch_recreate_flag_rebuilds_and_clears_stale_runs(tmp_path):
+    path = _sqlite_path(tmp_path, "rebuild.db")
+    rc = cli.main(["-db_url", _db_url(path), "import", "-f", MONUMENTEN, "-t", "eaxmi", "-db_create"])
+    assert rc == 0
+    assert len(_fetch_runs(path)) == 1
+    _tamper_datamodel_version(path)
+
+    rc = cli.main(
+        ["-db_url", _db_url(path), "-on_version_mismatch", "recreate", "import", "-f", MONUMENTEN, "-t", "eaxmi"]
+    )
+    assert rc == 0
+    assert _read_version(path) == str(DATAMODEL_VERSION)
+    runs = _fetch_runs(path)
+    assert len(runs) == 1, "recreate must clear stale run markers (their data is gone)"
+    assert runs[0][3] is not None
+
+
+def test_version_mismatch_on_default_db_still_recreates(tmp_path):
+    # Backwards compatibility: the local default database keeps the historical
+    # recreate behaviour under 'auto'. conftest patches const.DATABASE_URL to
+    # a sqlite file, so cli.main without -db_url hits the "default" branch.
+    default_path = const.DATABASE_URL.replace("sqlite:///", "")
+    rc = cli.main(["import", "-f", MONUMENTEN, "-t", "eaxmi", "-db_create"])
+    assert rc == 0
+    _tamper_datamodel_version(default_path)
+
+    rc = cli.main(["import", "-f", MONUMENTEN, "-t", "eaxmi"])
+    assert rc == 0, "default database must recreate on mismatch (historical behaviour)"
+    assert _read_version(default_path) == str(DATAMODEL_VERSION)
+
+
+def test_start_and_complete_run_via_database_api(tmp_path):
+    path = _sqlite_path(tmp_path, "api.db")
+    database = db.Database(_db_url(path), db_create=True)
+    try:
+        run_id = database.start_import_run("myschema")
+        assert run_id is not None
+        with database.engine.connect() as connection:
+            row = connection.execute(
+                select(crunch_runs_table.c.completed_at).where(crunch_runs_table.c.run_id == run_id)
+            ).first()
+        assert row is not None and row[0] is None
+
+        database.complete_import_run(run_id)
+        with database.engine.connect() as connection:
+            row = connection.execute(
+                select(crunch_runs_table.c.completed_at).where(crunch_runs_table.c.run_id == run_id)
+            ).first()
+        assert row is not None and row[0] is not None
+    finally:
+        database.close()

--- a/test/unit/test_32_diagram_geometry_model.py
+++ b/test/unit/test_32_diagram_geometry_model.py
@@ -9,8 +9,11 @@ additive migration of pre-existing database files.
 import json
 import sqlite3
 
+import pytest
+
 import crunch_uml.schema as sch
 from crunch_uml import const, db
+from crunch_uml.exceptions import CrunchException
 
 SCHEMA = "diagram_geometry_test"
 WAYPOINTS = json.dumps([{"x": 226.0, "y": 205.0}, {"x": 256.0, "y": 205.0}])
@@ -379,8 +382,9 @@ def test_datamodel_version_is_stamped_and_kept_out_of_exports():
 
 
 def test_incompatible_datamodel_version_recreates_database(tmp_path):
-    """A database with a different datamodel version is incompatible: it is
-    recreated from scratch on connect (data discarded) and restamped."""
+    """A database with a different datamodel version is incompatible. Since
+    v0.5.1 the default policy ('auto') REFUSES to touch an explicitly
+    addressed database; recreation must be requested explicitly."""
     path = tmp_path / "incompatible_version.db"
     raw = sqlite3.connect(path)
     raw.execute("CREATE TABLE packages (id VARCHAR NOT NULL, schema_id VARCHAR NOT NULL, PRIMARY KEY (id, schema_id))")
@@ -393,9 +397,18 @@ def test_incompatible_datamodel_version_recreates_database(tmp_path):
     saved_instance = db.Database._instance
     db.Database._instance = None
     try:
-        database = db.Database(f"sqlite:///{path}")
-        # Recreated: the old package row is gone, the version is restamped
-        # and the full current table set exists.
+        # Default 'auto' policy on an explicit db_url: fail fast, touch nothing.
+        with pytest.raises(CrunchException):
+            db.Database(f"sqlite:///{path}")
+        if db.Database._instance is not None:
+            db.Database._instance.close()
+        raw = sqlite3.connect(path)
+        assert raw.execute("SELECT COUNT(*) FROM packages").fetchone()[0] == 1
+        assert raw.execute("SELECT value FROM crunch_uml_meta WHERE key='datamodel_version'").fetchone()[0] == "9999"
+        raw.close()
+
+        # Explicit recreate: old data gone, version restamped, full table set.
+        database = db.Database(f"sqlite:///{path}", on_version_mismatch=const.VERSION_MISMATCH_RECREATE)
         assert database.session.query(db.Package).count() == 0
         assert database._read_datamodel_version() == db.DATAMODEL_VERSION
         rows = database.session.query(db.DiagramClass).all()


### PR DESCRIPTION
# v0.5.1

This release makes crunch_uml usable as an import engine writing into a
**shared staging database** that another application reads from.

## What's new

- **Import-run markers for shared databases.** Every `import` invocation now
  records a row in a new `crunch_uml_runs` table (kept outside the ORM model,
  like `crunch_uml_meta`, so it never leaks into exports): `run_id`,
  `schema_id`, `started_at`, `crunch_version`, `datamodel_version`, and a
  `completed_at` that is stamped as the FINAL step after the import committed.
  A row with `completed_at` NULL marks an in-progress or aborted (torn) run —
  crunch_uml writes table by table rather than in one transaction, so reading
  along mid-import yields a torn model. External readers of a shared database
  (e.g. an import API) should only consume schemas whose latest run is
  completed. The markers use their own connection, so they survive a session
  rollback as evidence, and a database recreate clears them (the data they
  vouched for is gone).

  ```sql
  SELECT schema_id, started_at, completed_at, crunch_version
  FROM crunch_uml_runs ORDER BY started_at DESC LIMIT 5;